### PR TITLE
Fixed VisRec API maven coordinates to javax.visrec.visrec-api:1.0.1

### DIFF
--- a/deepnetts-examples/pom.xml
+++ b/deepnetts-examples/pom.xml
@@ -16,8 +16,8 @@
         </dependency>
         <dependency>
             <groupId>javax.visrec</groupId>
-            <artifactId>VisualRecognitionApi</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <artifactId>visrec-api</artifactId>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.knowm.xchart</groupId>


### PR DESCRIPTION
I got an error when running:

```
mvn package
```

from the `communityedition` branch, from the root of the repo folder. 

I found that the `pom.xml` was referencing an older `VisRecAPI` coordinates so I fixed, it and it builds fine now:

```
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for DeepNetts 1.1-SNAPSHOT:
[INFO]
[INFO] DeepNetts .......................................... SUCCESS [  0.016 s]
[INFO] deepnetts-core-ce .................................. SUCCESS [  7.509 s]
[INFO] deepnetts-examples ................................. SUCCESS [  0.212 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.941 s
[INFO] Finished at: 2021-01-23T17:52:08Z
[INFO] ------------------------------------------------------------------------
```

Please let me know if the fix is desired or should the maven coordinates for `VisRecAPI` point to elsewhere?