### PR TITLE
Bringing all version numbers in sync with each other

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ mvn exec:java -Dexec.mainClass=deepnetts.examples.[Class name]
 or 
 
 cd deepnetts
-java -cp target/deepnetts-examples-1.1-SNAPSHOT.jar deepnetts.examples.[Class name]
+java -cp target/deepnetts-examples-1.12.jar deepnetts.examples.[Class name]
 ```
 
 Here is a list of `Class name`s to select from:
@@ -85,7 +85,7 @@ mvn exec:java -Dexec.mainClass=deepnetts.examples.IrisFlowersClassifier
 or 
 
 ```
-java -cp target/deepnetts-examples-1.1-SNAPSHOT.jar deepnetts.examples.IrisFlowersClassifier
+java -cp target/deepnetts-examples-1.12.jar deepnetts.examples.IrisFlowersClassifier
 ```
 
 

--- a/deepnetts-examples/pom.xml
+++ b/deepnetts-examples/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.deepnetts</groupId>
-    <version>1.11</version>
+    <version>1.12</version>
     <artifactId>deepnetts-examples</artifactId>
     <name>com.deepnetts:deepnetts-examples</name>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>deepnetts</groupId>
     <artifactId>DeepNetts</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.12</version>
     <packaging>pom</packaging>
     <modules>
         <module>deepnetts-examples</module>


### PR DESCRIPTION
Ensuring all versions referred to the in the README.md are in sync with that of the `pom.xml` in the `deepnetts-examples` and  the parent project. At the moment we have set the version to be `1.11`